### PR TITLE
Make throttle configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A port of [ng-infinite-scroll](https://github.com/sroze/ngInfiniteScroll) direct
 ## Supported API
 Currently supports:
 * (attribute) "infinite-scroll-distance" - should get a number
+* (attribute) "infinite-scroll-throttle" - should get a number of milliseconds for throttle (optional - default: 300) 
 * (function) - instead of defining a callback function on the "infinite-scroll" attribute, you should use the event binding **(scrolled)="handleScrollCallback()"**
 
 ## Usage
@@ -20,6 +21,7 @@ import { InfiniteScroll } from 'angular2-infinite-scroll';
 		<div class="search-results"
 		    infinite-scroll
 		    [infiniteScrollDistance]="2"
+		    [infiniteScrollThrottle]="500"
 		    (scrolled)="onScroll()">
 		</div>
 	`

--- a/bundles/angular2-infinite-scroll.js
+++ b/bundles/angular2-infinite-scroll.js
@@ -25,9 +25,7 @@ System.registerDynamic("src/infinite-scroll", ["@angular/core", "./scroller"], t
   var InfiniteScroll = (function() {
     function InfiniteScroll(element) {
       this.element = element;
-      this._distance = 2;
       this.scrolled = new core_1.EventEmitter();
-      this._throttle = 300;
     }
     Object.defineProperty(InfiniteScroll.prototype, "infiniteScrollDistance", {
       set: function(distance) {
@@ -36,24 +34,13 @@ System.registerDynamic("src/infinite-scroll", ["@angular/core", "./scroller"], t
       enumerable: true,
       configurable: true
     });
-    Object.defineProperty(InfiniteScroll.prototype, "infiniteScrollThrottle", {
-      set: function(throttle) {
-        this._throttle = throttle;
-      },
-      enumerable: true,
-      configurable: true
-    });
     InfiniteScroll.prototype.ngOnInit = function() {
-      this.scroller = new scroller_1.Scroller(window, setInterval, this.element, this.onScroll.bind(this), this._distance, {}, this._throttle);
-    };
-    InfiniteScroll.prototype.ngOnDestroy = function() {
-      this.scroller.clean();
+      this.scroller = new scroller_1.Scroller(window, setInterval, this.element, this.onScroll.bind(this), this._distance, {});
     };
     InfiniteScroll.prototype.onScroll = function() {
       this.scrolled.next({});
     };
     __decorate([core_1.Input(), __metadata('design:type', Number), __metadata('design:paramtypes', [Number])], InfiniteScroll.prototype, "infiniteScrollDistance", null);
-    __decorate([core_1.Input(), __metadata('design:type', Number), __metadata('design:paramtypes', [Number])], InfiniteScroll.prototype, "infiniteScrollThrottle", null);
     __decorate([core_1.Output(), __metadata('design:type', Object)], InfiniteScroll.prototype, "scrolled", void 0);
     InfiniteScroll = __decorate([core_1.Directive({selector: '[infinite-scroll]'}), __metadata('design:paramtypes', [core_1.ElementRef])], InfiniteScroll);
     return InfiniteScroll;
@@ -69,8 +56,8 @@ System.registerDynamic("src/scroller", [], true, function($__require, exports, m
       global = this,
       GLOBAL = this;
   var Scroller = (function() {
-    function Scroller($window, $interval, $elementRef, infiniteScrollCallback, infiniteScrollDistance, infiniteScrollParent, infiniteScrollThrottle) {
-      var THROTTLE_MILLISECONDS = infiniteScrollThrottle;
+    function Scroller($window, $interval, $elementRef, infiniteScrollCallback, infiniteScrollDistance, infiniteScrollParent) {
+      var THROTTLE_MILLISECONDS = 300;
       this.windowElement = $window;
       this.infiniteScrollCallback = infiniteScrollCallback;
       this.$interval = $interval;
@@ -150,12 +137,10 @@ System.registerDynamic("src/scroller", [], true, function($__require, exports, m
       timeout = null;
       previous = 0;
       later = function() {
-        var context;
         previous = new Date().getTime();
         clearInterval(timeout);
         timeout = null;
         func.call(_self);
-        return context = null;
       };
       return function() {
         var now,
@@ -179,17 +164,9 @@ System.registerDynamic("src/scroller", [], true, function($__require, exports, m
       return this.scrollDistance = parseFloat(v) || 0;
     };
     Scroller.prototype.changeContainer = function(newContainer) {
-      this.clean();
       this.container = newContainer;
       if (newContainer != null) {
-        this.bindedHandler = this.handler.bind(this);
-        return this.container.addEventListener('scroll', this.bindedHandler);
-      }
-    };
-    Scroller.prototype.clean = function() {
-      if (this.container !== undefined) {
-        this.container.removeEventListener('scroll', this.bindedHandler);
-        this.bindedHandler = null;
+        return this.container.addEventListener('scroll', this.handler.bind(this));
       }
     };
     Scroller.prototype.handleInfiniteScrollDisabled = function(v) {

--- a/bundles/angular2-infinite-scroll.js
+++ b/bundles/angular2-infinite-scroll.js
@@ -27,6 +27,7 @@ System.registerDynamic("src/infinite-scroll", ["@angular/core", "./scroller"], t
       this.element = element;
       this._distance = 2;
       this.scrolled = new core_1.EventEmitter();
+      this._throttle = 300;
     }
     Object.defineProperty(InfiniteScroll.prototype, "infiniteScrollDistance", {
       set: function(distance) {
@@ -35,8 +36,15 @@ System.registerDynamic("src/infinite-scroll", ["@angular/core", "./scroller"], t
       enumerable: true,
       configurable: true
     });
+    Object.defineProperty(InfiniteScroll.prototype, "infiniteScrollThrottle", {
+      set: function(throttle) {
+        this._throttle = throttle;
+      },
+      enumerable: true,
+      configurable: true
+    });
     InfiniteScroll.prototype.ngOnInit = function() {
-      this.scroller = new scroller_1.Scroller(window, setInterval, this.element, this.onScroll.bind(this), this._distance, {});
+      this.scroller = new scroller_1.Scroller(window, setInterval, this.element, this.onScroll.bind(this), this._distance, {}, this._throttle);
     };
     InfiniteScroll.prototype.ngOnDestroy = function() {
       this.scroller.clean();
@@ -45,6 +53,7 @@ System.registerDynamic("src/infinite-scroll", ["@angular/core", "./scroller"], t
       this.scrolled.next({});
     };
     __decorate([core_1.Input(), __metadata('design:type', Number), __metadata('design:paramtypes', [Number])], InfiniteScroll.prototype, "infiniteScrollDistance", null);
+    __decorate([core_1.Input(), __metadata('design:type', Number), __metadata('design:paramtypes', [Number])], InfiniteScroll.prototype, "infiniteScrollThrottle", null);
     __decorate([core_1.Output(), __metadata('design:type', Object)], InfiniteScroll.prototype, "scrolled", void 0);
     InfiniteScroll = __decorate([core_1.Directive({selector: '[infinite-scroll]'}), __metadata('design:paramtypes', [core_1.ElementRef])], InfiniteScroll);
     return InfiniteScroll;
@@ -60,8 +69,8 @@ System.registerDynamic("src/scroller", [], true, function($__require, exports, m
       global = this,
       GLOBAL = this;
   var Scroller = (function() {
-    function Scroller($window, $interval, $elementRef, infiniteScrollCallback, infiniteScrollDistance, infiniteScrollParent) {
-      var THROTTLE_MILLISECONDS = 300;
+    function Scroller($window, $interval, $elementRef, infiniteScrollCallback, infiniteScrollDistance, infiniteScrollParent, infiniteScrollThrottle) {
+      var THROTTLE_MILLISECONDS = infiniteScrollThrottle;
       this.windowElement = $window;
       this.infiniteScrollCallback = infiniteScrollCallback;
       this.$interval = $interval;

--- a/src/infinite-scroll.ts
+++ b/src/infinite-scroll.ts
@@ -7,9 +7,14 @@ import { Scroller } from './scroller';
 export class InfiniteScroll implements OnDestroy, OnInit {
   private scroller: Scroller;
   private _distance: number = 2;
+  private _throttle: number = 300;
 
   @Input() set infiniteScrollDistance(distance: number) {
     this._distance = distance;
+  }
+
+  @Input() set infiniteScrollThrottle(throttle: number) {
+    this._throttle = throttle;
   }
 
   @Output() scrolled = new EventEmitter();
@@ -17,7 +22,8 @@ export class InfiniteScroll implements OnDestroy, OnInit {
   constructor(private element: ElementRef) {}
 
   ngOnInit() {
-    this.scroller = new Scroller(window, setInterval, this.element, this.onScroll.bind(this), this._distance, {});
+    this.scroller = new Scroller(window, setInterval, this.element, this.onScroll.bind(this), this._distance, {}
+        , this._throttle);
   }
 
   ngOnDestroy () {

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -19,9 +19,10 @@ export class Scroller {
 		$elementRef: any,
 		infiniteScrollCallback: any,
 		infiniteScrollDistance: number,
-		infiniteScrollParent: any
+		infiniteScrollParent: any,
+		infiniteScrollThrottle: number
 		) {
-		let THROTTLE_MILLISECONDS = 300;
+		let THROTTLE_MILLISECONDS = infiniteScrollThrottle;
 		this.windowElement = $window;
 		this.infiniteScrollCallback = infiniteScrollCallback;
 		this.$interval = $interval;


### PR DESCRIPTION
This PR adds a new attribute to the directive (`infiniteScrollThrottle`), which lets the user configure the number of milliseconds to use for the throttle function. This attribute is optional, the default value remains at 300.