### PR TITLE
Horizontal scroll

### DIFF
--- a/src/axis-resolver.spec.ts
+++ b/src/axis-resolver.spec.ts
@@ -1,0 +1,44 @@
+import { it, describe, expect, async, inject } from '@angular/core/testing';
+
+import { InfiniteScroll }                      from './infinite-scroll'; 
+import { AxisResolver }                        from './axis-resolver';
+import { ElementRef }                          from '@angular/core'; 
+
+describe('AxisResolver Class', () => {
+  const makeMockElement =
+    (): ElementRef => { return new ElementRef(document.createElement('div'));};
+
+  const base_names = ['clientHeight', 'offsetHeight', 'scrollHeight'];
+
+  it('should create an instance of AxisResolver', () => {
+    const testResolver = new AxisResolver();
+
+    expect(testResolver).toEqual(jasmine.any(AxisResolver));
+  });
+
+  it('should default constructor arg to true', () => {
+    const defaultResolver  = new AxisResolver();
+    const verticalResolver = new AxisResolver(true);
+
+    const results          = defaultResolver.topKey();
+
+    expect(results).toBe(verticalResolver.topKey());
+  });
+
+  it('should change topKey() to "left" if created "horizontal"', () => {
+    const horizontalResolver = new AxisResolver(false);
+
+    expect(horizontalResolver.topKey()).toBe('left');
+  });
+
+  it('should make Height into Width if created "horizontal"', () => {
+    const horizontalResolver = new AxisResolver(false);
+
+    const methodNames = base_names.map( (name) => name + 'Key' );
+    const results = methodNames.map( (mName) => horizontalResolver[mName]() );
+    const are_widths = results.map( (result) => result.match(/Width/) );
+
+    expect( are_widths.every( (elt) => elt ) ).toBe(true);
+  });
+
+})

--- a/src/axis-resolver.ts
+++ b/src/axis-resolver.ts
@@ -1,0 +1,13 @@
+export class AxisResolver {
+  private vertical: boolean; // else horizontal
+
+  constructor(vertical: boolean) {}
+
+  clientHeightKey() {return this.vertical ? 'clientHeight' : 'clientWidth'}
+  offsetHeightKey() {return this.vertical ? 'offsetHeight' : 'offsetWidth'}
+  scrollHeightKey() {return this.vertical ? 'scrollHeight' : 'scrollWidth'}
+  pageYOffsetKey()  {return this.vertical ? 'pageYOffset'  : 'pageXOffset'}
+  offsetTopKey()    {return this.vertical ? 'offsetTop'    : 'offsetLeft'}
+  scrollTopKey()    {return this.vertical ? 'scrollTop'    : 'scrollLeft'}
+  topKey()          {return this.vertical ? 'top'          : 'left'}
+}

--- a/src/axis-resolver.ts
+++ b/src/axis-resolver.ts
@@ -1,7 +1,9 @@
 export class AxisResolver {
   private vertical: boolean; // else horizontal
 
-  constructor(vertical: boolean) {}
+  constructor(vertical = true) {
+    this.vertical = vertical;
+  }
 
   clientHeightKey() {return this.vertical ? 'clientHeight' : 'clientWidth'}
   offsetHeightKey() {return this.vertical ? 'offsetHeight' : 'offsetWidth'}

--- a/src/infinite-scroll.ts
+++ b/src/infinite-scroll.ts
@@ -29,12 +29,12 @@ export class InfiniteScroll implements OnDestroy, OnInit {
     this.scroller.clean();
   }
 
-  onScrollDown() {
-    this.scrolled.next({});
+  onScrollDown(data = {}) {
+    this.scrolled.next(data);
   }
 
-  onScrollUp() {
-    this.scrolledUp.next({});
+  onScrollUp(data = {}) {
+    this.scrolledUp.next(data);
   }
 
   @HostListener('scroll', ['$event'])

--- a/src/infinite-scroll.ts
+++ b/src/infinite-scroll.ts
@@ -12,6 +12,8 @@ export class InfiniteScroll implements OnDestroy, OnInit {
   @Input('infiniteScrollThrottle') _throttle: number = 3;
   @Input('scrollWindow') scrollWindow: boolean = true;
   @Input('immediateCheck') _immediate: boolean = false;
+  @Input('horizontal') _horizontal: boolean = false;
+  @Input('alwaysCallback') _alwaysCallback: boolean = false;
 
   @Output() scrolled = new EventEmitter();
   @Output() scrolledUp = new EventEmitter();
@@ -22,7 +24,8 @@ export class InfiniteScroll implements OnDestroy, OnInit {
     const containerElement = this.scrollWindow ? window : this.element;
     this.scroller = new Scroller(containerElement, setInterval, this.element,
         this.onScrollDown.bind(this), this.onScrollUp.bind(this),
-        this._distanceDown, this._distanceUp, {}, this._throttle, this._immediate);
+        this._distanceDown, this._distanceUp, {}, this._throttle,
+        this._immediate, this._horizontal, this._alwaysCallback);
   }
 
   ngOnDestroy () {

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -15,7 +15,7 @@ export class Scroller {
 	private isContainerWindow: boolean;
 	private disposeScroll: Subscription;
 	public lastScrollPosition: number = 0;
-  private axis: AxisResolver;
+	private axis: AxisResolver;
 
 	constructor(
 		private windowElement: Window | ElementRef | any,
@@ -41,7 +41,7 @@ export class Scroller {
 		this.handleInfiniteScrollDisabled(false);
 		this.defineContainer();
 		this.createInterval();
-    this.axis = new AxisResolver(!this.horizontal);
+		this.axis = new AxisResolver(!this.horizontal);
 	}
 
 	defineContainer () {
@@ -61,8 +61,8 @@ export class Scroller {
 	}
 
 	height (elem: any) {
-    let offsetHeight = this.axis.offsetHeightKey();
-    let clientHeight = this.axis.clientHeightKey();
+		let offsetHeight = this.axis.offsetHeightKey();
+		let clientHeight = this.axis.clientHeightKey();
 
 		// elem = elem.nativeElement;
 		if (isNaN(elem[offsetHeight])) {
@@ -73,7 +73,7 @@ export class Scroller {
 	}
 
 	offsetTop (elem: any) {
-    let top = this.axis.topKey();
+		let top = this.axis.topKey();
 
 		// elem = elem.nativeElement;
 		if (!elem.getBoundingClientRect) { // || elem.css('none')) {
@@ -83,9 +83,9 @@ export class Scroller {
 	}
 
 	pageYOffset (elem: any) {
-    let pageYOffset = this.axis.pageYOffsetKey();
-    let scrollTop   = this.axis.scrollTopKey();
-    let offsetTop   = this.axis.offsetTopKey();
+		let pageYOffset = this.axis.pageYOffsetKey();
+		let scrollTop   = this.axis.scrollTopKey();
+		let offsetTop   = this.axis.offsetTopKey();
 
 		// elem = elem.nativeElement;
 		if (isNaN(window[pageYOffset])) {
@@ -148,8 +148,8 @@ export class Scroller {
 	}
 
 	calculatePointsForElement () {
-    let scrollTop    = this.axis.scrollTopKey();
-    let scrollHeight = this.axis.scrollHeightKey();
+		let scrollTop    = this.axis.scrollTopKey();
+		let scrollHeight = this.axis.scrollHeightKey();
 
 		const height = this.height(this.container);
 		// perhaps use this.container.offsetTop instead of 'scrollTop'

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -1,5 +1,6 @@
 import { ElementRef } from '@angular/core';
 import { Observable, Subscription } from 'rxjs/Rx';
+import { AxisResolver } from './axis-resolver';
 
 export class Scroller {
 	public scrollDownDistance: number;
@@ -14,6 +15,7 @@ export class Scroller {
 	private isContainerWindow: boolean;
 	private disposeScroll: Subscription;
 	public lastScrollPosition: number = 0;
+  private axis: AxisResolver;
 
 	constructor(
 		private windowElement: Window | ElementRef | any,
@@ -39,15 +41,8 @@ export class Scroller {
 		this.handleInfiniteScrollDisabled(false);
 		this.defineContainer();
 		this.createInterval();
+    this.axis = new AxisResolver(!this.horizontal);
 	}
-
-  clientHeightKey() {return !this.horizontal ? 'clientHeight' : 'clientWidth'}
-  offsetHeightKey() {return !this.horizontal ? 'offsetHeight' : 'offsetWidth'}
-  scrollHeightKey() {return !this.horizontal ? 'scrollHeight' : 'scrollWidth'}
-  pageYOffsetKey()  {return !this.horizontal ? 'pageYOffset'  : 'pageXOffset'}
-  offsetTopKey()    {return !this.horizontal ? 'offsetTop'    : 'offsetLeft'}
-  scrollTopKey()    {return !this.horizontal ? 'scrollTop'    : 'scrollLeft'}
-  topKey()          {return !this.horizontal ? 'top'          : 'left'}
 
 	defineContainer () {
 		if (this.isContainerWindow) {
@@ -66,8 +61,8 @@ export class Scroller {
 	}
 
 	height (elem: any) {
-    let offsetHeight = this.offsetHeightKey();
-    let clientHeight = this.clientHeightKey();
+    let offsetHeight = this.axis.offsetHeightKey();
+    let clientHeight = this.axis.clientHeightKey();
 
 		// elem = elem.nativeElement;
 		if (isNaN(elem[offsetHeight])) {
@@ -78,7 +73,7 @@ export class Scroller {
 	}
 
 	offsetTop (elem: any) {
-    let top = this.topKey();
+    let top = this.axis.topKey();
 
 		// elem = elem.nativeElement;
 		if (!elem.getBoundingClientRect) { // || elem.css('none')) {
@@ -88,9 +83,9 @@ export class Scroller {
 	}
 
 	pageYOffset (elem: any) {
-    let pageYOffset = this.pageYOffsetKey();
-    let scrollTop   = this.scrollTopKey();
-    let offsetTop   = this.offsetTopKey();
+    let pageYOffset = this.axis.pageYOffsetKey();
+    let scrollTop   = this.axis.scrollTopKey();
+    let offsetTop   = this.axis.offsetTopKey();
 
 		// elem = elem.nativeElement;
 		if (isNaN(window[pageYOffset])) {
@@ -153,8 +148,8 @@ export class Scroller {
 	}
 
 	calculatePointsForElement () {
-    let scrollTop    = this.scrollTopKey();
-    let scrollHeight = this.scrollHeightKey();
+    let scrollTop    = this.axis.scrollTopKey();
+    let scrollHeight = this.axis.scrollHeightKey();
 
 		const height = this.height(this.container);
 		// perhaps use this.container.offsetTop instead of 'scrollTop'

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -57,10 +57,10 @@ export class Scroller {
 
 	height (elem: any) {
 		// elem = elem.nativeElement;
-		if (isNaN(elem.offsetHeight)) {
-			return this.documentElement.clientHeight;
+		if (isNaN(elem.offsetWidth)) {              // HZ offsetHeight offsetWidth
+			return this.documentElement.clientWidth;  // HZ clientHeight clientWidth
 		} else {
-			return elem.offsetHeight;
+			return elem.offsetWidth;                  // HZ offsetHeight offsetWidth
 		}
 	}
 
@@ -69,17 +69,17 @@ export class Scroller {
 		if (!elem.getBoundingClientRect) { // || elem.css('none')) {
 			return;
 		}
-		return elem.getBoundingClientRect().top + this.pageYOffset(elem);
+		return elem.getBoundingClientRect().left + this.pageYOffset(elem); // HZ top left
 	}
 
 	pageYOffset (elem: any) {
 		// elem = elem.nativeElement;
-		if (isNaN(window.pageYOffset)) {
-			return this.documentElement.scrollTop;
+		if (isNaN(window.pageXOffset)) {                     // HZ pageYOffset pageXOffset
+			return this.documentElement.scrollLeft;            // HZ scrollTop scrollLeft
 		} else if (elem.ownerDocument) {
-			return elem.ownerDocument.defaultView.pageYOffset;
+			return elem.ownerDocument.defaultView.pageXOffset; // HZ pageYOffset pageXOffset
 		} else {
-			elem.offsetTop;
+			return elem.offsetLeft;                            // HZ offsetTop offsetLeft
 		}
 	}
 
@@ -136,13 +136,13 @@ export class Scroller {
 	calculatePointsForElement () {
 		const height = this.height(this.container);
 		// perhaps use this.container.offsetTop instead of 'scrollTop'
-		const scrolledUntilNow = this.container.scrollTop;
+		const scrolledUntilNow = this.container.scrollLeft;  // HZ scrollTop scrollLeft
 		let containerTopOffset = 0;
 		const offsetTop = this.offsetTop(this.container);
 		if (offsetTop !== void 0) {
 			containerTopOffset = offsetTop;
 		}
-		const totalToScroll = this.container.scrollHeight;
+		const totalToScroll = this.container.scrollWidth;  // HZ scrollHeight scrollWidth
 		// const totalToScroll = this.offsetTop(this.$elementRef.nativeElement) - containerTopOffset + this.height(this.$elementRef.nativeElement);
 		return { height, scrolledUntilNow, totalToScroll };
 	}

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -25,7 +25,8 @@ export class Scroller {
 		infiniteScrollUpDistance: number,
 		infiniteScrollParent: Window | ElementRef | any,
 		private infiniteScrollThrottle: number,
-		private isImmediate: boolean
+		private isImmediate: boolean,
+		private horizontal: boolean = true
 	) {
 		this.isContainerWindow = toString.call(this.windowElement).includes('Window');
 		this.documentElement = this.isContainerWindow ? this.windowElement.document.documentElement : null;
@@ -38,6 +39,14 @@ export class Scroller {
 		this.defineContainer();
 		this.createInterval();
 	}
+
+  clientHeightKey() {return !this.horizontal ? 'clientHeight' : 'clientWidth'}
+  offsetHeightKey() {return !this.horizontal ? 'offsetHeight' : 'offsetWidth'}
+  scrollHeightKey() {return !this.horizontal ? 'scrollHeight' : 'scrollWidth'}
+  pageYOffsetKey()  {return !this.horizontal ? 'pageYOffset'  : 'pageXOffset'}
+  offsetTopKey()    {return !this.horizontal ? 'offsetTop'    : 'offsetLeft'}
+  scrollTopKey()    {return !this.horizontal ? 'scrollTop'    : 'scrollLeft'}
+  topKey()          {return !this.horizontal ? 'top'          : 'left'}
 
 	defineContainer () {
 		if (this.isContainerWindow) {
@@ -56,30 +65,39 @@ export class Scroller {
 	}
 
 	height (elem: any) {
+    let offsetHeight = this.offsetHeightKey();
+    let clientHeight = this.clientHeightKey();
+
 		// elem = elem.nativeElement;
-		if (isNaN(elem.offsetWidth)) {              // HZ offsetHeight offsetWidth
-			return this.documentElement.clientWidth;  // HZ clientHeight clientWidth
+		if (isNaN(elem[offsetHeight])) {
+			return this.documentElement[clientHeight];
 		} else {
-			return elem.offsetWidth;                  // HZ offsetHeight offsetWidth
+			return elem[offsetHeight];
 		}
 	}
 
 	offsetTop (elem: any) {
+    let top = this.topKey();
+
 		// elem = elem.nativeElement;
 		if (!elem.getBoundingClientRect) { // || elem.css('none')) {
 			return;
 		}
-		return elem.getBoundingClientRect().left + this.pageYOffset(elem); // HZ top left
+		return elem.getBoundingClientRect()[top] + this.pageYOffset(elem);
 	}
 
 	pageYOffset (elem: any) {
+    let pageYOffset = this.pageYOffsetKey();
+    let scrollTop   = this.scrollTopKey();
+    let offsetTop   = this.offsetTopKey();
+
 		// elem = elem.nativeElement;
-		if (isNaN(window.pageXOffset)) {                     // HZ pageYOffset pageXOffset
-			return this.documentElement.scrollLeft;            // HZ scrollTop scrollLeft
+		if (isNaN(window[pageYOffset])) {
+			return this.documentElement[scrollTop];
 		} else if (elem.ownerDocument) {
-			return elem.ownerDocument.defaultView.pageXOffset; // HZ pageYOffset pageXOffset
+			return elem.ownerDocument.defaultView[pageYOffset];
 		} else {
-			return elem.offsetLeft;                            // HZ offsetTop offsetLeft
+			return elem[offsetTop];
 		}
 	}
 
@@ -134,15 +152,18 @@ export class Scroller {
 	}
 
 	calculatePointsForElement () {
+    let scrollTop    = this.scrollTopKey();
+    let scrollHeight = this.scrollHeightKey();
+
 		const height = this.height(this.container);
 		// perhaps use this.container.offsetTop instead of 'scrollTop'
-		const scrolledUntilNow = this.container.scrollLeft;  // HZ scrollTop scrollLeft
+		const scrolledUntilNow = this.container[scrollTop];
 		let containerTopOffset = 0;
 		const offsetTop = this.offsetTop(this.container);
 		if (offsetTop !== void 0) {
 			containerTopOffset = offsetTop;
 		}
-		const totalToScroll = this.container.scrollWidth;  // HZ scrollHeight scrollWidth
+		const totalToScroll = this.container[scrollHeight];
 		// const totalToScroll = this.offsetTop(this.$elementRef.nativeElement) - containerTopOffset + this.height(this.$elementRef.nativeElement);
 		return { height, scrolledUntilNow, totalToScroll };
 	}

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -26,7 +26,8 @@ export class Scroller {
 		infiniteScrollParent: Window | ElementRef | any,
 		private infiniteScrollThrottle: number,
 		private isImmediate: boolean,
-		private horizontal: boolean = true
+		private horizontal: boolean = false,
+		private alwaysCallback: boolean = false
 	) {
 		this.isContainerWindow = toString.call(this.windowElement).includes('Window');
 		this.documentElement = this.isContainerWindow ? this.windowElement.document.documentElement : null;
@@ -116,7 +117,7 @@ export class Scroller {
 			containerBreakpoint = container.height * this.scrollUpDistance + 1;
 		}
 		const shouldScroll: boolean = remaining <= containerBreakpoint;
-		const triggerCallback: boolean = true // shouldScroll && this.scrollEnabled;
+		const triggerCallback: boolean = (this.alwaysCallback || shouldScroll) && this.scrollEnabled;
 		const shouldClearInterval = shouldScroll && this.checkInterval;
 		// if (this.useDocumentBottom) {
 		// 	container.totalToScroll = this.height(this.$elementRef.nativeElement.ownerDocument);

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -98,7 +98,7 @@ export class Scroller {
 			containerBreakpoint = container.height * this.scrollUpDistance + 1;
 		}
 		const shouldScroll: boolean = remaining <= containerBreakpoint;
-		const triggerCallback: boolean = shouldScroll && this.scrollEnabled;
+		const triggerCallback: boolean = true // shouldScroll && this.scrollEnabled;
 		const shouldClearInterval = shouldScroll && this.checkInterval;
 		// if (this.useDocumentBottom) {
 		// 	container.totalToScroll = this.height(this.$elementRef.nativeElement.ownerDocument);
@@ -107,9 +107,9 @@ export class Scroller {
 
 		if (triggerCallback) {
 			if (scrollingDown) {
-				this.infiniteScrollDownCallback();
+				this.infiniteScrollDownCallback({currentScrollPosition: container.scrolledUntilNow});
 			} else {
-				this.infiniteScrollUpCallback();
+				this.infiniteScrollUpCallback({currentScrollPosition: container.scrolledUntilNow});
 			}
 		}
 		if (shouldClearInterval) {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -19,6 +19,8 @@
     "../typings/index.d.ts",
     "./infinite-scroll.ts",
     "./infinite-scroll.spec.ts",
-    "./scroller.ts"
+    "./scroller.ts",
+    "./axis-resolver.ts",
+    "./axis-resolver.spec.ts"
     ]
 }


### PR DESCRIPTION
I've been working on adding horizontal scrolling.  Are you open to a PR?

There are two main issues:
 1) Switching property names when accessing DOM elements (eg clientHeight vs clientWidth).  Scroller and InfiniteScroll now have an addition boolean parameter 'horizontal'

 2) As far as triggering events (scrolledUp/scrolled) I needed a bit more control for what I was doing.  I needed to know the actual scroll position, so I added another parameter 'alwaysCallback' and made the callbacks include the scroll position (container.scrolledUntilNow) in the $event data.

![screen shot 2016-06-24 at 10 54 44 pm](https://cloud.githubusercontent.com/assets/990041/16355297/926108f2-3a67-11e6-9d92-1fa231d0908e.png)

LMK if you're interested; I can also point you to this app I'm using to test.