### PR TITLE
Only run setInterval if immediateCheck is enabled

### DIFF
--- a/bundles/angular2-infinite-scroll.js
+++ b/bundles/angular2-infinite-scroll.js
@@ -97,11 +97,11 @@ System.registerDynamic("src/scroller", ["rxjs/Rx"], true, function($__require, e
     };
     Scroller.prototype.createInterval = function() {
       var _this = this;
-      this.checkInterval = this.$interval(function() {
-        if (_this.isImmediate) {
+      if (this.isImmediate) {
+        this.checkInterval = this.$interval(function() {
           return _this.handler();
-        }
-      }, 0);
+        }, 0);
+      }
     };
     Scroller.prototype.height = function(elem) {
       if (isNaN(elem.offsetHeight)) {

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -48,11 +48,11 @@ export class Scroller {
 	}
 
 	createInterval () {
-		this.checkInterval = this.$interval(() => {
-			if (this.isImmediate) {
+		if (this.isImmediate) {
+			this.checkInterval = this.$interval(() => {
 				return this.handler();
-			}
-		}, 0);
+			}, 0);
+		}
 	}
 
 	height (elem: any) {


### PR DESCRIPTION
This PR should fix #40 by not creating an interval if it is not needed.