### PR TITLE
Add only the rxjs operators needed by the lib

### DIFF
--- a/bundles/angular2-infinite-scroll.js
+++ b/bundles/angular2-infinite-scroll.js
@@ -74,14 +74,17 @@ System.registerDynamic("src/infinite-scroll", ["@angular/core", "./scroller"], t
   return module.exports;
 });
 
-System.registerDynamic("src/scroller", ["rxjs/Rx", "./axis-resolver"], true, function($__require, exports, module) {
+System.registerDynamic("src/scroller", ["rxjs/Observable", "./axis-resolver", "rxjs/add/observable/fromEvent", "rxjs/add/observable/timer", "rxjs/add/operator/debounce"], true, function($__require, exports, module) {
   "use strict";
   ;
   var define,
       global = this,
       GLOBAL = this;
-  var Rx_1 = $__require('rxjs/Rx');
+  var Observable_1 = $__require('rxjs/Observable');
   var axis_resolver_1 = $__require('./axis-resolver');
+  $__require('rxjs/add/observable/fromEvent');
+  $__require('rxjs/add/observable/timer');
+  $__require('rxjs/add/operator/debounce');
   var Scroller = (function() {
     function Scroller(windowElement, $interval, $elementRef, infiniteScrollDownCallback, infiniteScrollUpCallback, infiniteScrollDownDistance, infiniteScrollUpDistance, infiniteScrollParent, infiniteScrollThrottle, isImmediate, horizontal, alwaysCallback) {
       if (horizontal === void 0) {
@@ -219,8 +222,8 @@ System.registerDynamic("src/scroller", ["rxjs/Rx", "./axis-resolver"], true, fun
       this.container = newContainer;
       if (newContainer) {
         var throttle_1 = this.infiniteScrollThrottle;
-        this.disposeScroll = Rx_1.Observable.fromEvent(this.container, 'scroll').debounce(function(ev) {
-          return Rx_1.Observable.timer(throttle_1);
+        this.disposeScroll = Observable_1.Observable.fromEvent(this.container, 'scroll').debounce(function(ev) {
+          return Observable_1.Observable.timer(throttle_1);
         }).subscribe(function(ev) {
           return _this.handler();
         });

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -1,6 +1,10 @@
 import { ElementRef } from '@angular/core';
-import { Observable, Subscription } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
 import { AxisResolver } from './axis-resolver';
+import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/observable/timer';
+import 'rxjs/add/operator/debounce';
 
 export class Scroller {
 	public scrollDownDistance: number;


### PR DESCRIPTION
This PR fixes an issue that I encountered using the angular2-infinite-scroll in my project.

I've configured my project to use only a subset of the RXJS operators to avoid to fetch all the big RXJS library. But, even after this configuration, my project was still fetching all the RXJS library. After debugging I found out that angular2-infinite-scroll was importing all the RXJS library and using only a few operators.

So, this PR replaces the big import with specific import for each operator. This reduces **a lot** the required amount of data fetched by the application.

Regarding, 

Bernardo Pacheco