### PR TITLE
Use local typings installation instead of global one for npm postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "start": "npm run build && npm run lite",
     "lite": "lite-server",
     "prepublish": "tsc & node make.js",
-    "postinstall": "typings install",
+    "postinstall": "npm run typings -- install",
     "clean": "rimraf src/*.js && rimraf src/*.d.ts && rimraf ./*scroll.js && rimraf ./*scroll.d.ts",
     "build:test": "tsc --project ./src",
     "watch": "tsc --project ./src --watch",
     "pretest": "npm run clean && npm run build:test",
     "test": "karma start karma.conf.js",
-    "dev": "npm run watch & npm test"
+    "dev": "npm run watch & npm test",
+    "typings": "typings"
   },
   "keywords": [
     "angular2",


### PR DESCRIPTION
When using `typings install` npm will depend on the globally installed typings package. By adding typings as npm run target and calling it within from another run target, typings from the local node_modules directory will be used, as they are added to the path. Therefore it is not necessary to have typings installed globally in order to build this project. 