### PR TITLE
Use rxjs throttle instead of debounce

### DIFF
--- a/bundles/angular2-infinite-scroll.js
+++ b/bundles/angular2-infinite-scroll.js
@@ -74,7 +74,7 @@ System.registerDynamic("src/infinite-scroll", ["@angular/core", "./scroller"], t
   return module.exports;
 });
 
-System.registerDynamic("src/scroller", ["rxjs/Observable", "./axis-resolver", "rxjs/add/observable/fromEvent", "rxjs/add/observable/timer", "rxjs/add/operator/debounce"], true, function($__require, exports, module) {
+System.registerDynamic("src/scroller", ["rxjs/Observable", "./axis-resolver", "rxjs/add/observable/fromEvent", "rxjs/add/observable/timer", "rxjs/add/operator/throttle"], true, function($__require, exports, module) {
   "use strict";
   ;
   var define,
@@ -84,7 +84,7 @@ System.registerDynamic("src/scroller", ["rxjs/Observable", "./axis-resolver", "r
   var axis_resolver_1 = $__require('./axis-resolver');
   $__require('rxjs/add/observable/fromEvent');
   $__require('rxjs/add/observable/timer');
-  $__require('rxjs/add/operator/debounce');
+  $__require('rxjs/add/operator/throttle');
   var Scroller = (function() {
     function Scroller(windowElement, $interval, $elementRef, infiniteScrollDownCallback, infiniteScrollUpCallback, infiniteScrollDownDistance, infiniteScrollUpDistance, infiniteScrollParent, infiniteScrollThrottle, isImmediate, horizontal, alwaysCallback) {
       if (horizontal === void 0) {
@@ -222,7 +222,7 @@ System.registerDynamic("src/scroller", ["rxjs/Observable", "./axis-resolver", "r
       this.container = newContainer;
       if (newContainer) {
         var throttle_1 = this.infiniteScrollThrottle;
-        this.disposeScroll = Observable_1.Observable.fromEvent(this.container, 'scroll').debounce(function(ev) {
+        this.disposeScroll = Observable_1.Observable.fromEvent(this.container, 'scroll').throttle(function(ev) {
           return Observable_1.Observable.timer(throttle_1);
         }).subscribe(function(ev) {
           return _this.handler();

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -4,7 +4,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { AxisResolver } from './axis-resolver';
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/observable/timer';
-import 'rxjs/add/operator/debounce';
+import 'rxjs/add/operator/throttle';
 
 export class Scroller {
 	public scrollDownDistance: number;
@@ -179,7 +179,7 @@ export class Scroller {
 		if (newContainer) {
 			const throttle: number = this.infiniteScrollThrottle;
 			this.disposeScroll = Observable.fromEvent(this.container, 'scroll')
-				.debounce(ev => Observable.timer(throttle))
+				.throttle(ev => Observable.timer(throttle))
 				.subscribe(ev => this.handler())
 		}
 	}


### PR DESCRIPTION
This PR switches the throttle function of the scroller from [rxjs debounce](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/debounce.md) to [rxjs throttle](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/throttle.md). This is desirable because debounce fires the first event after the configured amount of time has passed, while throttle fires immediately and discards all events after the first in the configured time interval. By switching to throttle the scrolling becomes more responsive (especially for longer throttle times like 600ms). This also restores the behavior before the switch to rxjs.