### PR TITLE
fix(package): stop using typings on postinstall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 
 install:
 - npm install
+- npm run setup
 
 after_script: 
 - process.exit()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "npm run build && npm run lite",
     "lite": "lite-server",
     "prepublish": "tsc & node make.js",
-    "postinstall": "npm run typings -- install",
+    "setup": "npm run typings -- install",
     "clean": "rimraf src/*.js && rimraf src/*.d.ts && rimraf ./*scroll.js && rimraf ./*scroll.d.ts",
     "build:test": "tsc --project ./src",
     "watch": "tsc --project ./src --watch",


### PR DESCRIPTION
Now, Installation is fail when an user isn't using `typings`. 
Please stop using `postinstall` for developing.

Thanks.