### PR TITLE
Fix the default throttle

### DIFF
--- a/src/infinite-scroll.spec.ts
+++ b/src/infinite-scroll.spec.ts
@@ -24,15 +24,18 @@ describe('Infinite Scroll Directive', () => {
 
   it('should have default @Input properties values', () => {
     const directive = createInfiniteScroll();
-    const expectedInputs = [
-      '_distanceDown',
-      '_distanceUp',
-      '_throttle',
-      'scrollWindow',
-      '_immediate'
-    ];
-    expectedInputs.forEach(actualInput =>
-      expect(directive[actualInput]).toBeDefined());
+    const expectedInputs = {
+      _distanceDown: 2,
+      _distanceUp: 1.5,
+      _throttle: 300,
+      scrollWindow: true,
+      _immediate: false,
+      _horizontal: false,
+      _alwaysCallback: false
+    };
+
+    Object.keys(expectedInputs).forEach(input =>
+      expect(directive[input]).toEqual(expectedInputs[input]));
   });
 
   it('should trigger the onScrollDown event when scroll has passed _distandDown', () => {

--- a/src/infinite-scroll.ts
+++ b/src/infinite-scroll.ts
@@ -9,7 +9,7 @@ export class InfiniteScroll implements OnDestroy, OnInit {
 
   @Input('infiniteScrollDistance') _distanceDown: number = 2;
   @Input('infiniteScrollUpDistance') _distanceUp: number = 1.5;
-  @Input('infiniteScrollThrottle') _throttle: number = 3;
+  @Input('infiniteScrollThrottle') _throttle: number = 300;
   @Input('scrollWindow') scrollWindow: boolean = true;
   @Input('immediateCheck') _immediate: boolean = false;
   @Input('horizontal') _horizontal: boolean = false;


### PR DESCRIPTION
The Rxjs throttle function expects the time in milliseconds so the existing default  value of the input (3) does not match the documented default.

https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/throttle.md