### PR TITLE
fix(infinite-scroll): fix destroy of scroller on server

### DIFF
--- a/src/infinite-scroll.ts
+++ b/src/infinite-scroll.ts
@@ -36,7 +36,9 @@ export class InfiniteScroll implements OnDestroy, OnInit, OnChanges {
   }
 
   ngOnDestroy () {
-    this.scroller.clean();
+    if (this.scroller) {
+      this.scroller.clean();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/src/infinite-scroll.ts
+++ b/src/infinite-scroll.ts
@@ -27,12 +27,14 @@ export class InfiniteScroll implements OnDestroy, OnInit, OnChanges {
   ) {}
 
   ngOnInit() {
-    const containerElement = this.scrollWindow ? window : this.element;
-    this.scroller = new Scroller(containerElement, setInterval, this.element,
-        this.onScrollDown.bind(this), this.onScrollUp.bind(this),
-        this._distanceDown, this._distanceUp, {}, this._throttle,
-        this._immediate, this._horizontal, this._alwaysCallback,
-        this._disabled, this.axis);
+    if (typeof window !== 'undefined') {
+      const containerElement = this.scrollWindow ? window : this.element;
+      this.scroller = new Scroller(containerElement, setInterval, this.element,
+          this.onScrollDown.bind(this), this.onScrollUp.bind(this),
+          this._distanceDown, this._distanceUp, {}, this._throttle,
+          this._immediate, this._horizontal, this._alwaysCallback,
+          this._disabled, this.axis);
+    }
   }
 
   ngOnDestroy () {


### PR DESCRIPTION
Using this directive on server-rendered views with angular/universal breaks with the error:

TypeError: Cannot read property 'clean' of undefined
    at InfiniteScroll.ngOnDestroy (infinite-scroll.ts:32:18)