### PR TITLE
Support for AOT compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Desktop.ini
 .tmp
 typings
 .tags*
+
+src/ngFactory
+*.metadata.json
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,6 @@ Thumbs.db
 # Ignored files
 *.ts
 !*.d.ts
+
+# ngc generated files
+src/ngFactory

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "npm run watch & karma start karma.conf.js --bdd",
     "lite": "lite-server",
     "postversion": "git push origin master",
-    "prepublish": "tsc && node make.js",
+    "prepublish": "node ./node_modules/@angular/compiler-cli/src/main.js && node make.js",
     "pretest": "npm run clean && npm run build:test",
     "preversion": "npm run clean && npm run prepublish && npm test",
     "setup": "npm run typings -- install",
@@ -30,11 +30,12 @@
   "author": "Oren Farhi",
   "license": "MIT",
   "devDependencies": {
-    "@angular/common": "2.0.0",
-    "@angular/compiler": "2.0.0",
-    "@angular/core": "2.0.0",
-    "@angular/platform-browser": "2.0.0",
-    "@angular/platform-browser-dynamic": "2.0.0",
+    "@angular/common": "2.0.1",
+    "@angular/compiler": "2.0.1",
+    "@angular/compiler-cli": "^0.6.2",
+    "@angular/core": "2.0.1",
+    "@angular/platform-browser": "2.0.1",
+    "@angular/platform-browser-dynamic": "2.0.1",
     "@types/core-js": "^0.9.32",
     "@types/jasmine": "^2.2.33",
     "@types/node": "^6.0.38",
@@ -64,9 +65,9 @@
     "ts-helpers": "^1.1.1",
     "tslint": "^3.15.1",
     "tslint-loader": "^2.1.5",
-    "typescript": "2.0.0",
+    "typescript": "2.0.3",
+    "typings": "1.2.0",
     "webpack": "2.1.0-beta.21",
-    "zone.js": "^0.6.17",
-    "typings": "1.2.0"
+    "zone.js": "^0.6.17"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,35 +1,42 @@
 {
-	"compilerOptions": {
-	    "noImplicitAny": true,
-      "module": "commonjs",
-      "target": "es5",
-      "emitDecoratorMetadata": true,
-      "experimentalDecorators": true,
-      "inlineSourceMap": true,
-      "inlineSources": true,
-      "declaration": true,
-      "suppressImplicitAnyIndexErrors": true,
-      "moduleResolution": "node",
-      "lib": ["dom", "es6"],
-      "types": [
-        "jasmine",
-        "node"
-      ]
-	},
-	"exclude": [
-		"node_modules",
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "module": "commonjs",
+    "target": "es5",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "lib": [
+      "dom",
+      "es6"
+    ],
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "exclude": [
+    "node_modules",
     "bundles"
-	],
+  ],
   "awesomeTypescriptLoaderOptions": {
     "forkChecker": true,
     "useWebpackText": true
   },
-	"files": [
+  "files": [
     // "./typings/index.d.ts",
-		"./angular2-infinite-scroll.ts",
-		"./src/infinite-scroll.ts",
-		"./src/scroller.ts",
+    "./angular2-infinite-scroll.ts",
+    "./src/infinite-scroll.ts",
+    "./src/scroller.ts",
     "./src/axis-resolver.ts",
     "./src/index.ts"
-	]
+  ],
+  "angularCompilerOptions": {
+    "genDir": "./src/ngfactory",
+    "debug": false
+  }
 }


### PR DESCRIPTION
Closes #77 

1. Added `@angular/compiler-cli` package
2. Run compiler at `prepublish` step
3. Compiler creates `*.metadata.json` files, which should be included to npm package
4. Ignore compile results in gitingnore